### PR TITLE
chore: upgarde eslint-plugin-lwc to 0.8.0

### DIFF
--- a/base.js
+++ b/base.js
@@ -15,6 +15,9 @@ module.exports = {
         // LWC lifecycle hooks validation
         '@lwc/lwc/no-deprecated': 'error',
 
+        // LWC public property syntax validation
+        '@lwc/lwc/no-leading-uppercase-api-name': 'error',
+
         // LWC decorator validation
         '@lwc/lwc/valid-api': 'error',
         '@lwc/lwc/valid-track': 'error',

--- a/base.js
+++ b/base.js
@@ -16,7 +16,7 @@ module.exports = {
         '@lwc/lwc/no-deprecated': 'error',
 
         // LWC public property syntax validation
-        '@lwc/lwc/no-leading-uppercase-api-name': 'error',
+        '@lwc/lwc/no-leading-uppercase-api-name': 'warn',
 
         // LWC decorator validation
         '@lwc/lwc/valid-api': 'error',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@lwc/eslint-plugin-lwc": "^0.6.0",
+    "@lwc/eslint-plugin-lwc": "^0.8.0",
     "babel-eslint": "^10.0.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && yarn format"
     }
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,10 +104,10 @@
     log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
-"@lwc/eslint-plugin-lwc@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.6.0.tgz#aa283547bb78a3843db49eb595a03ff91ef083f1"
-  integrity sha512-2iAzQTSUNYwmojh0Ey/ma4uRVpbU2t85Wf9+nkVqXkEyQBR1IFDB9PdPREbPZ8FrjQTlDek0TxSyzwz4wsdiSQ==
+"@lwc/eslint-plugin-lwc@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.8.0.tgz#40ed5b9809434f3bd901309359273d19c6c3e888"
+  integrity sha512-HV5gEcB9PuusAGgMtPWFEzal8cw3LmpXgVUOIpHQ1a/yoNyn9Jofo8eur51yjgTSjHJGH0iqmjSLxmcvc1IAYA==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
eslint-plugin-lwc to 0.8.0 contains new rule that prevents upper case leading characters in @api names. This rule is now consumed as part of the base configuration. 