### PR TITLE
feat: Move no-leading-uppercase-api-name to recommended preset

### DIFF
--- a/base.js
+++ b/base.js
@@ -15,9 +15,6 @@ module.exports = {
         // LWC lifecycle hooks validation
         '@lwc/lwc/no-deprecated': 'error',
 
-        // LWC public property syntax validation
-        '@lwc/lwc/no-leading-uppercase-api-name': 'warn',
-
         // LWC decorator validation
         '@lwc/lwc/valid-api': 'error',
         '@lwc/lwc/valid-track': 'error',

--- a/recommended.js
+++ b/recommended.js
@@ -103,11 +103,12 @@ module.exports = {
 
         // LWC specific rules
         '@lwc/lwc/no-async-operation': 'error',
-        '@lwc/lwc/no-inner-html': 'error',
         '@lwc/lwc/no-document-query': 'error',
+        '@lwc/lwc/no-inner-html': 'error',
+        '@lwc/lwc/no-leading-uppercase-api-name': 'error',
 
         // Disable unresolved import rule since it doesn't work well with the way the LWC compiler
         // resolves the different modules
-        'import/no-unresolved': 0,
+        'import/no-unresolved': 'off',
     },
 };


### PR DESCRIPTION
## Changes

Since https://github.com/salesforce/lwc/pull/1687, LWC now capitalized public property names. 

This PR moves the `@lwc/lwc/no-leading-uppercase-api-name` linting rule from the `base` preset to the `recommended` preset.