### PR TITLE
feat(base-config): add no-unknown-wire-adapters and no-unexpected-wire-adapter-usages

### DIFF
--- a/base.js
+++ b/base.js
@@ -28,10 +28,6 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         identifier: 'CurrentPageReference',
     },
     {
-        module: 'lightning/uiActionsApi',
-        identifier: 'getLookupActions',
-    },
-    {
         module: 'lightning/uiLayoutApi',
         identifier: 'getLayout',
     },

--- a/base.js
+++ b/base.js
@@ -32,10 +32,6 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         identifier: 'getListUi',
     },
     {
-        module: 'lightning/uiLookupsApi',
-        identifier: 'getLookupRecords',
-    },
-    {
         module: 'lightning/uiObjectInfoApi',
         identifier: 'getObjectInfo',
     },

--- a/base.js
+++ b/base.js
@@ -55,30 +55,6 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         module: 'lightning/uiRecordApi',
         identifier: 'getRecordUi',
     },
-    {
-        module: 'lightning/uiRecordAvatarApi',
-        identifier: 'getRecordAvatars',
-    },
-    {
-        module: 'lightning/uiRelatedListApi',
-        identifier: 'getRelatedListInfo',
-    },
-    {
-        module: 'lightning/uiRelatedListApi',
-        identifier: 'getRelatedListInfos',
-    },
-    {
-        module: 'lightning/uiRelatedListApi',
-        identifier: 'getRelatedListRecords',
-    },
-    {
-        module: 'lightning/uiRelatedListApi',
-        identifier: 'getRelatedListsCount',
-    },
-    {
-        module: 'lightning/uiRelatedListApi',
-        identifier: 'getRelatedListsInfo',
-    },
 ];
 
 module.exports = {

--- a/base.js
+++ b/base.js
@@ -6,6 +6,113 @@
  */
 'use strict';
 
+const KNOWN_WIRE_ADAPTERS = [
+    {
+        module: 'lightning/**',
+        identifier: '*',
+    },
+    // All apex, apexContinuation methods
+    {
+        module: '@salesforce/**',
+        identifier: '*',
+    },
+];
+
+const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
+    {
+        module: 'lightning/communityNavigationMenuApi',
+        identifier: 'getCommunityNavigationMenu',
+    },
+    {
+        module: 'lightning/messageService',
+        identifier: 'MessageContext',
+    },
+    {
+        module: 'lightning/navigation',
+        identifier: 'CurrentPageReference',
+    },
+    {
+        module: 'lightning/uiActionsApi',
+        identifier: 'getLookupActions',
+    },
+    {
+        module: 'lightning/uiLayoutApi',
+        identifier: 'getLayout',
+    },
+    {
+        module: 'lightning/uiLayoutApi',
+        identifier: 'getLayoutUserState',
+    },
+    {
+        module: 'lightning/uiListApi',
+        identifier: 'getListUi',
+    },
+    {
+        module: 'lightning/uiLookupsApi',
+        identifier: 'getLookupRecords',
+    },
+    {
+        module: 'lightning/uiObjectInfoApi',
+        identifier: 'getObjectInfo',
+    },
+    {
+        module: 'lightning/uiObjectInfoApi',
+        identifier: 'getPicklistValues',
+    },
+    {
+        module: 'lightning/uiObjectInfoApi',
+        identifier: 'getPicklistValuesByRecordType',
+    },
+    {
+        module: 'lightning/uiRecordActionsApi',
+        identifier: 'getRecordActions',
+    },
+    {
+        module: 'lightning/uiRecordActionsApi',
+        identifier: 'getRecordEditActions',
+    },
+    {
+        module: 'lightning/uiRecordActionsApi',
+        identifier: 'getRelatedListRecordActions',
+    },
+    {
+        module: 'lightning/uiRecordApi',
+        identifier: 'getRecord',
+    },
+    {
+        module: 'lightning/uiRecordApi',
+        identifier: 'getRecordCreateDefaults',
+    },
+    {
+        module: 'lightning/uiRecordApi',
+        identifier: 'getRecordUi',
+    },
+    {
+        module: 'lightning/uiRecordAvatarApi',
+        identifier: 'getRecordAvatars',
+    },
+    {
+        module: 'lightning/uiRelatedListApi',
+        identifier: 'getRelatedListInfo',
+    },
+    {
+        module: 'lightning/uiRelatedListApi',
+        identifier: 'getRelatedListInfos',
+    },
+    {
+        module: 'lightning/uiRelatedListApi',
+        identifier: 'getRelatedListRecords',
+    },
+    {
+        module: 'lightning/uiRelatedListApi',
+        identifier: 'getRelatedListsCount',
+    },
+    {
+        module: 'lightning/uiRelatedListApi',
+        identifier: 'getRelatedListsInfo',
+    },
+];
+
 module.exports = {
     extends: [require.resolve('./lib/defaults')],
 
@@ -19,5 +126,19 @@ module.exports = {
         '@lwc/lwc/valid-api': 'error',
         '@lwc/lwc/valid-track': 'error',
         '@lwc/lwc/valid-wire': 'error',
+
+        // LWC wire adapters validation
+        '@lwc/lwc/no-unknown-wire-adapters': [
+            'error',
+            {
+                adapters: KNOWN_WIRE_ADAPTERS,
+            },
+        ],
+        '@lwc/lwc/no-unexpected-wire-adapter-usages': [
+            'error',
+            {
+                adapters: WIRE_ADAPTERS_WITH_RESTRICTED_USE,
+            },
+        ],
     },
 };

--- a/base.js
+++ b/base.js
@@ -44,18 +44,6 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         identifier: 'getPicklistValuesByRecordType',
     },
     {
-        module: 'lightning/uiRecordActionsApi',
-        identifier: 'getRecordActions',
-    },
-    {
-        module: 'lightning/uiRecordActionsApi',
-        identifier: 'getRecordEditActions',
-    },
-    {
-        module: 'lightning/uiRecordActionsApi',
-        identifier: 'getRelatedListRecordActions',
-    },
-    {
         module: 'lightning/uiRecordApi',
         identifier: 'getRecord',
     },

--- a/base.js
+++ b/base.js
@@ -28,14 +28,6 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         identifier: 'CurrentPageReference',
     },
     {
-        module: 'lightning/uiLayoutApi',
-        identifier: 'getLayout',
-    },
-    {
-        module: 'lightning/uiLayoutApi',
-        identifier: 'getLayoutUserState',
-    },
-    {
         module: 'lightning/uiListApi',
         identifier: 'getListUi',
     },

--- a/base.js
+++ b/base.js
@@ -20,10 +20,6 @@ const KNOWN_WIRE_ADAPTERS = [
 
 const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
     {
-        module: 'lightning/communityNavigationMenuApi',
-        identifier: 'getCommunityNavigationMenu',
-    },
-    {
         module: 'lightning/messageService',
         identifier: 'MessageContext',
     },

--- a/test/base.js
+++ b/test/base.js
@@ -40,4 +40,49 @@ describe('base config', () => {
         assert.equal(messages.length, 1);
         assert.equal(messages[0].ruleId, '@lwc/lwc/valid-api');
     });
+
+    it('should include @lwc/lwc/no-unknown-wire-adapters rule', () => {
+        const cli = new eslint.CLIEngine({
+            useEslintrc: false,
+            baseConfig: {
+                extends: '@salesforce/eslint-config-lwc/base',
+            },
+        });
+
+        const report = cli.executeOnText(`
+            import { wire } from 'lwc';
+            import { Baz } from 'c/cmp';
+            class Foo {
+                @wire(Baz)
+                foo;
+            }
+        `);
+
+        const { messages } = report.results[0];
+        assert.equal(messages.length, 1);
+        assert.equal(messages[0].ruleId, '@lwc/lwc/no-unknown-wire-adapters');
+    });
+
+    it('should include @lwc/lwc/no-unexpected-wire-adapter-usages', () => {
+        const cli = new eslint.CLIEngine({
+            useEslintrc: false,
+            baseConfig: {
+                extends: '@salesforce/eslint-config-lwc/base',
+            },
+        });
+
+        const report = cli.executeOnText(`
+            import { wire } from 'lwc';
+            import { CurrentPageReference } from 'lightning/navigation';
+            const reference = CurrentPageReference;
+            class Foo {
+                @wire(CurrentPageReference)
+                foo;
+            }
+        `);
+
+        const { messages } = report.results[0];
+        assert.equal(messages.length, 1);
+        assert.equal(messages[0].ruleId, '@lwc/lwc/no-unexpected-wire-adapter-usages');
+    });
 });


### PR DESCRIPTION
This PR adds and configures [@lwc/lwc/no-unknown-wire-adapters](https://github.com/salesforce/eslint-plugin-lwc/blob/master/docs/rules/no-unknown-wire-adapters.md) and [@lwc/lwc/no-unexpected-wire-adapter-usages](https://github.com/salesforce/eslint-plugin-lwc/blob/master/docs/rules/no-unexpected-wire-adapter-usages.md) rules to the base config.