### PR TITLE
feat: adding i18n rule set

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Installation
 
-```
-$ npm install --save-dev @salesforce/eslint-config-lwc @lwc/eslint-plugin-lwc @salesforce/eslint-plugin-lightning eslint-plugin-import eslint-plugin-jest
+```sh
+npm install --save-dev @salesforce/eslint-config-lwc @lwc/eslint-plugin-lwc @salesforce/eslint-plugin-lightning eslint-plugin-import eslint-plugin-jest
 ```
 
 Note that `@lwc/eslint-plugin-lwc`, `@salesforce/eslint-plugin-lightning`, `eslint-plugin-import`, and `eslint-plugin-jest` are peer dependencies of `@salesforce/eslint-config-lwc`.
@@ -26,7 +26,7 @@ For more details about configuration, please refer to the dedicated section in t
 
 ## Configurations
 
-This package exposes 3 configurations for your usage.
+This package exposes 4 configurations for your usage.
 
 ### `@salesforce/eslint-config-lwc/base` configuration
 
@@ -51,3 +51,21 @@ Restrict usage of some Javascript language features known to be slow after the _
 
 **Rules:**
 `@salesforce/eslint-config-lwc/recommended` rules + restrict usage of some slow patterns in [_COMPAT_](https://github.com/salesforce/eslint-plugin-lwc/blob/master/README.md#compat-performance).
+
+### `@salesforce/eslint-config-lwc/i18n` configuration
+
+**Goal:**
+Promote usage of `@salesforce/i18n-service` over 3rd parties, promote internationalization (I18N) best practices.
+
+**Rules:**
+[_I18N specific rules_](https://github.com/salesforce/eslint-plugin-lightning#internationalization-rules) only.
+
+**Usage:**
+
+Add the `i18n` configuration to the `extends` field in your `.eslintrc` configuration file, for example:
+
+```json
+{
+    "extends": ["@salesforce/eslint-config-lwc/recommended", "@salesforce/eslint-config-lwc/i18n"]
+}
+```

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+module.exports = {
+    plugins: ['@salesforce/eslint-plugin-lightning'],
+
+    rules: {
+        // I18N Rules
+        '@salesforce/lightning/no-aura-localization-service': 'warn',
+        '@salesforce/lightning/no-moment': 'warn',
+        '@salesforce/lightning/prefer-i18n-service': 'warn',
+    },
+};

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lib",
     "base.js",
     "extended.js",
+    "i18n.js",
     "index.js",
     "recommended.js"
   ],

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const assert = require('assert');
+const eslint = require('eslint');
+
+const { linkConfig, unlinkConfig } = require('./utils');
+
+describe('i18n configs', () => {
+    before(() => {
+        linkConfig();
+    });
+
+    after(() => {
+        unlinkConfig();
+    });
+
+    it('should load properly i18n config with other set', () => {
+        const cli = new eslint.CLIEngine({
+            useEslintrc: false,
+            baseConfig: {
+                extends: [
+                    '@salesforce/eslint-config-lwc/i18n',
+                    '@salesforce/eslint-config-lwc/base',
+                ],
+            },
+        });
+
+        const report = cli.executeOnText(`
+        var moment = require('moment');
+        var a = moment('2016-01-01'); 
+        a.format();
+        `);
+
+        const { messages } = report.results[0];
+        assert.equal(messages.length, 1);
+        assert.equal(messages[0].ruleId, '@salesforce/lightning/no-moment');
+    });
+
+    it('extended set should include @salesforce/lightning/no-moment rule', () => {
+        const cli = new eslint.CLIEngine({
+            useEslintrc: false,
+            baseConfig: {
+                extends: '@salesforce/eslint-config-lwc/i18n',
+            },
+        });
+
+        const report = cli.executeOnText(`
+        var moment = require('moment');
+        var a = moment('2016-01-01'); 
+        a.format();
+        `);
+
+        const { messages } = report.results[0];
+        assert.equal(messages.length, 1);
+        assert.equal(messages[0].ruleId, '@salesforce/lightning/no-moment');
+    });
+});


### PR DESCRIPTION
Adding configuration for I18N rules. This is to promote the use of @salesforce/localizer as a best practice for I18N in LWC:

Note that this change needs https://github.com/salesforce/eslint-plugin-lwc/pull/52 to be merged first.

I18N configuration contains following rules:

- `prefer-localizer`: give warnings (not errors), and suggest to use localizer over using Intl directly
- `no-moment`: discourage use of moment (again as a warning)
- `no-aura-localization-service`: will mark references to `$A.localizationService` as warnings (this is only used in Core).

This is 1st change, where existing configurations are untouched:

- Add a new `i18n` config that only includes those i18n rules - that can be added on top of other configs by devs who need it (e.g. in base-components) or want to test it. _Note_: this configuration generates warnings, and not errors like other lwc configs.

Then, when @salesforce/localizer is available in the public npm repository, update the existing sets:

- `recommended`: include prefer-localizer and no-moment with a warn level
- `extended`: include all 3 rules with a warn level
