### PR TITLE
chore: upgrade @lwc/eslint-plugin-lwc and add rules to recommended preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@lwc/eslint-plugin-lwc": "~0.10.0",
+    "@lwc/eslint-plugin-lwc": "~0.11.0",
     "babel-eslint": "~10.1.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-jest": "~23.8.2",

--- a/recommended.js
+++ b/recommended.js
@@ -105,6 +105,7 @@ module.exports = {
         '@lwc/lwc/no-api-reassignments': 'error',
         '@lwc/lwc/no-async-operation': 'error',
         '@lwc/lwc/no-document-query': 'error',
+        '@lwc/lwc/no-dupe-class-members': 'error',
         '@lwc/lwc/no-inner-html': 'error',
         '@lwc/lwc/no-leading-uppercase-api-name': 'error',
         '@lwc/lwc/prefer-custom-event': 'error',

--- a/recommended.js
+++ b/recommended.js
@@ -107,6 +107,12 @@ module.exports = {
         '@lwc/lwc/no-document-query': 'error',
         '@lwc/lwc/no-inner-html': 'error',
         '@lwc/lwc/no-leading-uppercase-api-name': 'error',
+        '@lwc/lwc/valid-api': [
+            'error',
+            {
+                disallowUnderscoreUppercaseMix: true,
+            },
+        ],
 
         // Disable unresolved import rule since it doesn't work well with the way the LWC compiler
         // resolves the different modules

--- a/recommended.js
+++ b/recommended.js
@@ -107,6 +107,7 @@ module.exports = {
         '@lwc/lwc/no-document-query': 'error',
         '@lwc/lwc/no-inner-html': 'error',
         '@lwc/lwc/no-leading-uppercase-api-name': 'error',
+        '@lwc/lwc/prefer-custom-event': 'error',
         '@lwc/lwc/valid-api': [
             'error',
             {

--- a/test/recommended.js
+++ b/test/recommended.js
@@ -63,4 +63,24 @@ describe('recommended config', () => {
         assert.equal(messages.length, 1);
         assert.equal(messages[0].ruleId, '@lwc/lwc/prefer-custom-event');
     });
+
+    it('should forbid duplicate class members', () => {
+        const cli = getCliEngineWithRecommendedRules();
+
+        const report = cli.executeOnText(`
+            import { LightningElement, api } from 'lwc';
+
+            export default class App extends LightningElement {
+                @api foo = 1;
+            
+                set foo(value) { this._foo = value }
+                get foo() { return this._foo; }
+            }
+        `);
+
+        const { messages } = report.results[0];
+        assert.equal(messages.length, 2);
+        assert.equal(messages[0].ruleId, '@lwc/lwc/no-dupe-class-members');
+        assert.equal(messages[1].ruleId, '@lwc/lwc/no-dupe-class-members');
+    });
 });

--- a/test/recommended.js
+++ b/test/recommended.js
@@ -34,4 +34,24 @@ describe('recommended config', () => {
         assert.equal(messages.length, 1);
         assert.equal(messages[0].ruleId, '@lwc/lwc/no-document-query');
     });
+
+    it('should forbid mixing uppercase and underscore characters in public properties', () => {
+        const cli = new eslint.CLIEngine({
+            useEslintrc: false,
+            baseConfig: {
+                extends: '@salesforce/eslint-config-lwc/recommended',
+            },
+        });
+
+        const report = cli.executeOnText(`
+            import { LightningElement, api } from 'lwc';
+            export default class Foo extends LightningElement {
+                @api bar_Foo() {}
+            }
+        `);
+
+        const { messages } = report.results[0];
+        assert.equal(messages.length, 1);
+        assert.equal(messages[0].ruleId, '@lwc/lwc/valid-api');
+    });
 });

--- a/test/recommended.js
+++ b/test/recommended.js
@@ -11,6 +11,15 @@ const eslint = require('eslint');
 
 const { linkConfig, unlinkConfig } = require('./utils');
 
+function getCliEngineWithRecommendedRules() {
+    return new eslint.CLIEngine({
+        useEslintrc: false,
+        baseConfig: {
+            extends: '@salesforce/eslint-config-lwc/recommended',
+        },
+    });
+}
+
 describe('recommended config', () => {
     before(() => {
         linkConfig();
@@ -21,12 +30,7 @@ describe('recommended config', () => {
     });
 
     it('should load properly recommended config', () => {
-        const cli = new eslint.CLIEngine({
-            useEslintrc: false,
-            baseConfig: {
-                extends: '@salesforce/eslint-config-lwc/recommended',
-            },
-        });
+        const cli = getCliEngineWithRecommendedRules();
 
         const report = cli.executeOnText('document.querySelectorAll("a")');
 
@@ -36,12 +40,7 @@ describe('recommended config', () => {
     });
 
     it('should forbid mixing uppercase and underscore characters in public properties', () => {
-        const cli = new eslint.CLIEngine({
-            useEslintrc: false,
-            baseConfig: {
-                extends: '@salesforce/eslint-config-lwc/recommended',
-            },
-        });
+        const cli = getCliEngineWithRecommendedRules();
 
         const report = cli.executeOnText(`
             import { LightningElement, api } from 'lwc';
@@ -53,5 +52,15 @@ describe('recommended config', () => {
         const { messages } = report.results[0];
         assert.equal(messages.length, 1);
         assert.equal(messages[0].ruleId, '@lwc/lwc/valid-api');
+    });
+
+    it('should suggest usage of CustomEvent over Event constructor', () => {
+        const cli = getCliEngineWithRecommendedRules();
+
+        const report = cli.executeOnText(`dispatchEvent(new Event('test'));`);
+
+        const { messages } = report.results[0];
+        assert.equal(messages.length, 1);
+        assert.equal(messages[0].ruleId, '@lwc/lwc/prefer-custom-event');
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,10 +126,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@lwc/eslint-plugin-lwc@~0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.10.0.tgz#e282910b01b3b403d8fec03d34c4c853e29c4676"
-  integrity sha512-UsosUow0xWrzzcSK1fWDWHKBT81/pJz1/icfv7w8T+BCE9G4Kb4TwJexHLOIZvY7e/dv4Fjme4lTOWehuNE5Sg==
+"@lwc/eslint-plugin-lwc@~0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.11.0.tgz#1c69cc673b9798e04e87ececb8529b93eb2215b1"
+  integrity sha512-wJOD4XWOH91GaZfypMSKfEeMXqMfvKdsb2gSJ/9FEwJVlziKg1aagtRYJh2ln3DyEZV33tBC/p/dWzIeiwa1tg==
   dependencies:
     minimatch "^3.0.4"
 


### PR DESCRIPTION
### Details

In this PR:
1. Configures `lwc/valid-api` in the recommended preset, disallowing mixed use of upper case and underscore in API fields and methods.
2. Adds `lwc/prefer-custom-event` to the recommended preset.
3. Adds `lwc/no-dupe-class-members` to the recommended preset.