### PR TITLE
fix: use backwards-compatible configuration for decorators plugin

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -16,6 +16,7 @@ module.exports = {
     parserOptions: {
         requireConfigFile: false,
         babelOptions: {
+            babelrc: false,
             parserOpts: {
                 plugins: ['classProperties', ['decorators', { decoratorsBeforeExport: false }]],
             },


### PR DESCRIPTION
Avoids the "Parsing error: Cannot use the decorators and decorators-legacy plugin together" parsing error when the consuming application uses the legacy decorators plugin. This configuration causes no issues when the consuming application is using the new decorators plugin.