### PR TITLE
feat: add the `commerce/cartApi:CartSummaryAdapter` to the known wire adapter list

### DIFF
--- a/base.js
+++ b/base.js
@@ -16,6 +16,10 @@ const KNOWN_WIRE_ADAPTERS = [
         module: '@salesforce/**',
         identifier: '*',
     },
+    {
+        module: 'commerce/cartApi',
+        identifier: 'CartSummaryAdapter',
+    },
 ];
 
 const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [


### PR DESCRIPTION
As referenced in Issue #52 : adding a new wire adapter to the known list. ✅ 