### PR TITLE
fix: use exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@lwc/eslint-plugin-lwc": "~0.12.2-232.0",
+    "@lwc/eslint-plugin-lwc": "0.12.2-232.0",
     "babel-eslint": "~10.1.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-jest": "~23.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,10 +146,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@lwc/eslint-plugin-lwc@~0.12.2-232.0":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.12.2.tgz#345d17c9f2ffd3579630659bdb0d8c90c2c16531"
-  integrity sha512-6BBp3bDAhf3no/cRADIlP3/dVm4eZ48sVwC/qYuRKnB843Qu1+rP4yzmZmTivApbetFkE+HN3ZQwcoMzj/smKw==
+"@lwc/eslint-plugin-lwc@0.12.2-232.0":
+  version "0.12.2-232.0"
+  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.12.2-232.0.tgz#cddfa56ba1c0fdf35fce9ef90d8d5d73f65e87ce"
+  integrity sha512-BfBC/gBLWuLKTcppsD36ciwLFhuugtyibowY2y/WQX7Rzz9aQhmqj8o6yP7RfEry80FuuG/aP1JIOWc2ozb1yQ==
   dependencies:
     minimatch "^3.0.4"
 


### PR DESCRIPTION
v0.12.2 gets picked up instead of v0.12.2-232.0 because the latter isn't semver compliant.