### PR TITLE
fix: enforces CartSummaryAdapter to be used only with wire decorator

### DIFF
--- a/base.js
+++ b/base.js
@@ -24,6 +24,10 @@ const KNOWN_WIRE_ADAPTERS = [
 
 const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
     {
+        module: 'commerce/cartApi',
+        identifier: 'CartSummaryAdapter',
+    },
+    {
         module: 'lightning/analyticsWaveApi',
         identifier: 'executeQuery',
     },


### PR DESCRIPTION
This `commerce/cartApi:CartSummaryAdapter` was added as part of https://github.com/salesforce/eslint-config-lwc/pull/53