### PR TITLE
chore: convert plugin dependencies to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 ## Installation
 
 ```
-$ npm install eslint @salesforce/eslint-config-lwc --save-dev
+$ npm install --save-dev @salesforce/eslint-config-lwc @lwc/eslint-plugin-lwc eslint eslint-plugin-import eslint-plugin-jest
 ```
+
+Note that `@lwc/eslint-plugin-lwc`, `eslint`, `eslint-plugin-import`, and `eslint-plugin-jest` are peer dependencies of `@salesforce/eslint-config-lwc`.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -19,20 +19,23 @@
   "dependencies": {
     "@babel/core": "~7.13.14",
     "@babel/eslint-parser": "~7.13.14",
-    "@lwc/eslint-plugin-lwc": "~1.0.0",
-    "eslint-plugin-import": "~2.22.1",
-    "eslint-plugin-jest": "~23.8.2",
     "eslint-restricted-globals": "~0.2.0"
   },
   "devDependencies": {
+    "@lwc/eslint-plugin-lwc": "~1.0.0",
     "eslint": "^7.22.0",
+    "eslint-plugin-import": "~2.22.1",
+    "eslint-plugin-jest": "~23.8.2",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.4",
     "mocha": "^8.3.2",
     "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "eslint": "^6 || ^7"
+    "@lwc/eslint-plugin-lwc": "~1.0.0",
+    "eslint": "^6 || ^7",
+    "eslint-plugin-import": "~2.22.1",
+    "eslint-plugin-jest": "~23.8.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The ESLint programming model considers shareable configs and plugins as peer dependencies so the way we currently have `eslint-plugin-lwc` as a dependency of `eslint-config-lwc` only works when they are treated as peers by package managers such as npm and yarn through hoisting. This breaking change removes plugins as dependencies and declares them as peer dependencies that must be installed by users of this package.

We can remove these peer dependencies when we upgrade to eslint v8 which will implement [a new configuration system](https://github.com/eslint/eslint/issues/13764#issuecomment-713031703) that will allow us to treat plugins as dependencies.

References:
- https://github.com/eslint/eslint/issues/3458
- https://github.com/eslint/eslint/issues/2518