### PR TITLE
[BREAKING] Integrate @salesforce/eslint-plugin-lightning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 ## Installation
 
 ```
-$ npm install --save-dev @salesforce/eslint-config-lwc @lwc/eslint-plugin-lwc eslint eslint-plugin-import eslint-plugin-jest
+$ npm install --save-dev @salesforce/eslint-config-lwc @lwc/eslint-plugin-lwc @salesforce/eslint-plugin-lightning eslint-plugin-import eslint-plugin-jest
 ```
 
-Note that `@lwc/eslint-plugin-lwc`, `eslint`, `eslint-plugin-import`, and `eslint-plugin-jest` are peer dependencies of `@salesforce/eslint-config-lwc`.
+Note that `@lwc/eslint-plugin-lwc`, `@salesforce/eslint-plugin-lightning`, `eslint-plugin-import`, and `eslint-plugin-jest` are peer dependencies of `@salesforce/eslint-config-lwc`.
 
 ## Usage
 

--- a/base.js
+++ b/base.js
@@ -128,7 +128,9 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
 module.exports = {
     extends: [require.resolve('./lib/defaults')],
 
-    plugins: ['@lwc/eslint-plugin-lwc'],
+    plugins: [
+        '@lwc/eslint-plugin-lwc', // https://github.com/salesforce/eslint-plugin-lwc
+    ],
 
     rules: {
         // LWC lifecycle hooks validation

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@lwc/eslint-plugin-lwc": "~1.0.0",
+    "@salesforce/eslint-plugin-lightning": "^0.1.0",
     "eslint": "^7.22.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-jest": "~23.8.2",
@@ -33,6 +34,7 @@
   },
   "peerDependencies": {
     "@lwc/eslint-plugin-lwc": "~1.0.0",
+    "@salesforce/eslint-plugin-lightning": "^0.1.0",
     "eslint": "^6 || ^7",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-jest": "~23.8.2"

--- a/recommended.js
+++ b/recommended.js
@@ -9,13 +9,17 @@
 const restrictedGlobals = require('eslint-restricted-globals');
 
 module.exports = {
-    plugins: ['import', 'jest'],
+    plugins: [
+        'import', // https://github.com/benmosher/eslint-plugin-import
+        'jest', // https://github.com/jest-community/eslint-plugin-jest
+        '@salesforce/eslint-plugin-lightning', // https://github.com/salesforce/eslint-plugin-lightning
+    ],
 
     extends: [
         require.resolve('./base'),
-        'eslint:recommended', // https://eslint.org/docs/rules/
-        'plugin:import/errors', // https://github.com/benmosher/eslint-plugin-import
-        'plugin:jest/recommended', // https://github.com/jest-community/eslint-plugin-jest
+        'eslint:recommended',
+        'plugin:import/errors',
+        'plugin:jest/recommended',
     ],
 
     env: {
@@ -116,6 +120,9 @@ module.exports = {
                 disallowUnderscoreUppercaseMix: true,
             },
         ],
+
+        // Lightning
+        '@salesforce/lightning/valid-apex-method-invocation': 'error',
 
         // Disable unresolved import rule since it doesn't work well with the way the LWC compiler
         // resolves the different modules

--- a/test/recommended.js
+++ b/test/recommended.js
@@ -102,4 +102,20 @@ describe('recommended config', () => {
         assert.strictEqual(messages.length, 1);
         assert.strictEqual(messages[0].ruleId, '@lwc/lwc/no-attributes-during-construction');
     });
+
+    it('should prevent invalid usage of Apex method', () => {
+        const cli = getCliEngineWithRecommendedRules();
+
+        const report = cli.executeOnText(`
+            import findContacts from '@salesforce/apex/ContactController.findContacts';
+            findContacts('Ted');
+        `);
+
+        const { messages } = report.results[0];
+        assert.strictEqual(messages.length, 1);
+        assert.strictEqual(
+            messages[0].ruleId,
+            '@salesforce/lightning/valid-apex-method-invocation',
+        );
+    });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -8,16 +8,10 @@
 
 const fs = require('fs');
 const path = require('path');
-const eslint = require('eslint');
 
-const SCOPE_DIRECTORY = path.resolve(__dirname, '../node_modules/@salesforce');
-const PACKAGE_DIRECTORY = path.resolve(SCOPE_DIRECTORY, 'eslint-config-lwc');
+const PACKAGE_DIRECTORY = path.resolve(__dirname, '../node_modules/@salesforce/eslint-config-lwc');
 
 function linkConfig() {
-    if (!fs.existsSync(SCOPE_DIRECTORY)) {
-        fs.mkdirSync(SCOPE_DIRECTORY);
-    }
-
     if (!fs.existsSync(PACKAGE_DIRECTORY)) {
         fs.symlinkSync(path.resolve(__dirname, '..'), PACKAGE_DIRECTORY, 'dir');
     }
@@ -27,25 +21,9 @@ function unlinkConfig() {
     if (fs.existsSync(PACKAGE_DIRECTORY)) {
         fs.unlinkSync(PACKAGE_DIRECTORY);
     }
-
-    if (fs.existsSync(SCOPE_DIRECTORY)) {
-        fs.rmdirSync(SCOPE_DIRECTORY);
-    }
-}
-
-function lintText(text, config) {
-    const cli = new eslint.CLIEngine({
-        useEslintrc: false,
-        baseConfig: config,
-    });
-
-    const report = cli.executeOnText(text);
-
-    return report.results[0];
 }
 
 module.exports = {
     linkConfig,
     unlinkConfig,
-    lintText,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,6 +232,11 @@
   dependencies:
     minimatch "^3.0.4"
 
+"@salesforce/eslint-plugin-lightning@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/eslint-plugin-lightning/-/eslint-plugin-lightning-0.1.0.tgz#836f9578454be338425fbfc806e4380a7e0cd202"
+  integrity sha512-eMJtc8zafGcrMHRuSta0zxpNXDj+B1MnDDccIMHWwT/PBHIKewZuUCU6D5fOEseID2+AIAXJXnJUrqsbMRUPjg==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"


### PR DESCRIPTION
This PR integrates `@salesforce/eslint-plugin-lightning` new plugin to the repository. It adds the `@salesforce/lightning/valid-apex-method-invocation` to the recommended set of rules. 

**⚠️ This is PR introduces a breaking change as it requires `@salesforce/eslint-plugin-lightning`  to be installed as peer dependency ⚠️**