### PR TITLE
fix: Drop support for eslint@6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,33 +24,8 @@ jobs:
       - run: yarn lint
       - run: yarn test
 
-  test_eslint:
-    docker:
-      - image: circleci/node
-
-    parameters:
-      eslint:
-        type: string
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "yarn.lock" }}
-          - v1-dependencies-
-      
-      - run: yarn install --frozen-lock
-      - run: yarn add --dev eslint@<< parameters.eslint >>
-      - run: yarn test
 
 workflows:
   build_and_test:
     jobs:
       - build
-      - test_eslint:
-          requires:
-            - build
-          matrix:
-            parameters:
-              eslint: ["6", "7"]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@lwc/eslint-plugin-lwc": "^1.0.0",
     "@salesforce/eslint-plugin-lightning": "^0.1.0",
-    "eslint": "^6 || ^7",
+    "eslint": "^7",
     "eslint-plugin-import": "*",
     "eslint-plugin-jest": "*"
   },


### PR DESCRIPTION
When installing this package with eslint@6, the following message gets printed. ([example](https://app.circleci.com/pipelines/github/salesforce/eslint-config-lwc/155/workflows/04df0e57-427a-414a-ac69-37505747dbdb/jobs/274/parallel-runs/0/steps/0-104))

```
warning " > @babel/eslint-parser@7.13.14" has incorrect peer dependency "eslint@>=7.5.0".
warning " > @salesforce/eslint-plugin-lightning@0.1.0" has incorrect peer dependency "eslint@^7".
```