### PR TITLE
feat(commerce): updated registered 234 commerce adapters

### DIFF
--- a/base.js
+++ b/base.js
@@ -18,43 +18,8 @@ const KNOWN_WIRE_ADAPTERS = [
     },
     {
         module: 'commerce/cartApi',
-        identifier: 'CartSummaryAdapter',
+        identifier: 'CartItemsAdapter',
     },
-    {
-        module: 'commerce/contextApi',
-        identifier: 'AppContextAdapter',
-    },
-    {
-        module: 'commerce/contextApi',
-        identifier: 'SessionContextAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryHierarchyAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryPathAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductPricingAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductSearchAdapter',
-    },
-];
-
-const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
     {
         module: 'commerce/cartApi',
         identifier: 'CartSummaryAdapter',
@@ -87,9 +52,44 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         module: 'commerce/productApi',
         identifier: 'ProductPricingAdapter',
     },
+];
+
+const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
+    {
+        module: 'commerce/cartApi',
+        identifier: 'CartItemsAdapter',
+    },
+    {
+        module: 'commerce/cartApi',
+        identifier: 'CartSummaryAdapter',
+    },
+    {
+        module: 'commerce/contextApi',
+        identifier: 'AppContextAdapter',
+    },
+    {
+        module: 'commerce/contextApi',
+        identifier: 'SessionContextAdapter',
+    },
     {
         module: 'commerce/productApi',
-        identifier: 'ProductSearchAdapter',
+        identifier: 'ProductAdapter',
+    },
+    {
+        module: 'commerce/productApi',
+        identifier: 'ProductCategoryAdapter',
+    },
+    {
+        module: 'commerce/productApi',
+        identifier: 'ProductCategoryHierarchyAdapter',
+    },
+    {
+        module: 'commerce/productApi',
+        identifier: 'ProductCategoryPathAdapter',
+    },
+    {
+        module: 'commerce/productApi',
+        identifier: 'ProductPricingAdapter',
     },
     {
         module: 'lightning/analyticsWaveApi',


### PR DESCRIPTION
This PR updates the registered publicly available commerce wire adapters of RP 234:
* `commerce/cartApi/CartItemsAdapter` as it just got provided publicly today
* `commerce/productApi/ProductSearchAdapter` had to be removed as it turned out that the underlying Connect API is not meant to be consumed publicly, even though it is of course public as a Connect API 🤦. Apparently it got created by the holy ghost as no one wants to have been it...