### PR TITLE
fix: Avoid duplicate no-dupe-class-members warning with ESLint v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@babel/core": "~7.16.0",
     "@babel/eslint-parser": "~7.16.0",
-    "eslint-restricted-globals": "~0.2.0"
+    "eslint-restricted-globals": "~0.2.0",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@lwc/eslint-plugin-lwc": "^1.1.1",
@@ -31,8 +32,7 @@
     "husky": "^7.0.4",
     "lint-staged": "^11.2.6",
     "mocha": "^9.1.3",
-    "prettier": "^2.4.1",
-    "semver": "^7.3.5"
+    "prettier": "^2.4.1"
   },
   "peerDependencies": {
     "@lwc/eslint-plugin-lwc": "^1.0.0",

--- a/recommended.js
+++ b/recommended.js
@@ -6,6 +6,8 @@
  */
 'use strict';
 
+const semver = require('semver');
+const { ESLint } = require('eslint');
 const restrictedGlobals = require('eslint-restricted-globals');
 
 module.exports = {
@@ -110,7 +112,6 @@ module.exports = {
         '@lwc/lwc/no-async-operation': 'error',
         '@lwc/lwc/no-attributes-during-construction': 'error',
         '@lwc/lwc/no-document-query': 'error',
-        '@lwc/lwc/no-dupe-class-members': 'error',
         '@lwc/lwc/no-inner-html': 'error',
         '@lwc/lwc/no-leading-uppercase-api-name': 'error',
         '@lwc/lwc/no-template-children': 'error',
@@ -128,5 +129,11 @@ module.exports = {
         // Disable unresolved import rule since it doesn't work well with the way the LWC compiler
         // resolves the different modules
         'import/no-unresolved': 'off',
+
+        // Misc
+        // In ESLint v8 the built-in `no-dupe-class-member` rules added support for duplicated
+        // class fields. We should disable the `lwc/no-dupe-class-members` rule to avoid duplicated
+        // linting errors.
+        '@lwc/lwc/no-dupe-class-members': semver.lt(ESLint.version, '8.0.0') ? 'error' : 'off',
     },
 };

--- a/test/recommended.js
+++ b/test/recommended.js
@@ -87,15 +87,10 @@ describe('recommended config', () => {
         `);
 
         const { messages } = results[0];
-        const isEslint7 = semver.satisfies(eslint.ESLint.version, '^7');
-        const expected = isEslint7
+
+        const expected = semver.lt(eslint.ESLint.version, '8.0.0')
             ? ['@lwc/lwc/no-dupe-class-members', '@lwc/lwc/no-dupe-class-members']
-            : [
-                  '@lwc/lwc/no-dupe-class-members',
-                  'no-dupe-class-members',
-                  '@lwc/lwc/no-dupe-class-members',
-                  'no-dupe-class-members',
-              ];
+            : ['no-dupe-class-members', 'no-dupe-class-members'];
         assert.deepStrictEqual(
             messages.map((_) => _.ruleId),
             expected,


### PR DESCRIPTION
This PR disables the `lwc/no-dupe-class-members` rule when running ESLint v8. It prevents reporting twice the same duplicate field error message. 

Address this issue on the original ESLint v8 upgrade https://github.com/salesforce/eslint-config-lwc/pull/77#discussion_r746387800