### PR TITLE
Add customer facing lint rule to getListInfosByName Adapter

### DIFF
--- a/base.js
+++ b/base.js
@@ -232,6 +232,10 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         identifier: 'getListUi',
     },
     {
+        module: 'lightning/uiListsApi',
+        identifier: 'getListInfosByName',
+    },
+    {
         module: 'lightning/uiObjectInfoApi',
         identifier: 'getObjectInfo',
     },


### PR DESCRIPTION
[@W-10448072](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000gGWAcYAO/view)

Description
expose getListInfosByName wire adapter in lightning

Changes in this pull request
Added customer-facing lint rule to getListInfosByName wire adapter