### PR TITLE
Update base.js

### DIFF
--- a/base.js
+++ b/base.js
@@ -92,7 +92,7 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         identifier: 'SessionContextAdapter',
     },
     {
-        module: 'commerce/ecommendationsApi',
+        module: 'commerce/recommendationsApi',
         identifier: 'ProductRecommendationsAdapter',
     },
     {

--- a/base.js
+++ b/base.js
@@ -33,8 +33,8 @@ const KNOWN_WIRE_ADAPTERS = [
         identifier: 'SessionContextAdapter',
     },
     {
-        module: 'commerce/einsteinRecommendationsApi',
-        identifier: 'EinsteinProductRecommendationsAdapter',
+        module: 'commerce/recommendationsApi',
+        identifier: 'ProductRecommendationsAdapter',
     },
     {
         module: 'commerce/productApi',
@@ -92,8 +92,8 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
         identifier: 'SessionContextAdapter',
     },
     {
-        module: 'commerce/einsteinRecommendationsApi',
-        identifier: 'EinsteinProductRecommendationsAdapter',
+        module: 'commerce/ecommendationsApi',
+        identifier: 'ProductRecommendationsAdapter',
     },
     {
         module: 'commerce/productApi',


### PR DESCRIPTION
Removing `Einstein` branding from public apis introduced in 238.