### PR TITLE
feat: add support for pattern matching in rule no-unexpected-wire-adapter-usages

### DIFF
--- a/base.js
+++ b/base.js
@@ -16,120 +16,28 @@ const KNOWN_WIRE_ADAPTERS = [
         module: '@salesforce/**',
         identifier: '*',
     },
+    // All commerce API adapters
     {
-        module: 'commerce/cartApi',
-        identifier: 'CartItemsAdapter',
+        module: 'commerce/*Api',
+        identifier: '*',
     },
+    // All experience API adapters
     {
-        module: 'commerce/cartApi',
-        identifier: 'CartSummaryAdapter',
-    },
-    {
-        module: 'commerce/contextApi',
-        identifier: 'AppContextAdapter',
-    },
-    {
-        module: 'commerce/contextApi',
-        identifier: 'SessionContextAdapter',
-    },
-    {
-        module: 'commerce/recommendationsApi',
-        identifier: 'ProductRecommendationsAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryHierarchyAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryPathAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductPricingAdapter',
-    },
-    {
-        module: 'experience/cmsDeliveryApi',
-        identifier: 'getContent',
-    },
-    {
-        module: 'experience/cmsEditorApi',
-        identifier: 'getContent',
-    },
-    {
-        module: 'experience/cmsEditorApi',
-        identifier: 'getContext',
-    },
-    {
-        module: 'experience/navigationMenuApi',
-        identifier: 'getNavigationMenu',
+        module: 'experience/*Api',
+        identifier: '*',
     },
 ];
 
 const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
+    // All commerce API adapters
     {
-        module: 'commerce/cartApi',
-        identifier: 'CartItemsAdapter',
+        module: 'commerce/*Api',
+        identifier: '*',
     },
+    // All experience API adapters
     {
-        module: 'commerce/cartApi',
-        identifier: 'CartSummaryAdapter',
-    },
-    {
-        module: 'commerce/contextApi',
-        identifier: 'AppContextAdapter',
-    },
-    {
-        module: 'commerce/contextApi',
-        identifier: 'SessionContextAdapter',
-    },
-    {
-        module: 'commerce/recommendationsApi',
-        identifier: 'ProductRecommendationsAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryHierarchyAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductCategoryPathAdapter',
-    },
-    {
-        module: 'commerce/productApi',
-        identifier: 'ProductPricingAdapter',
-    },
-    {
-        module: 'experience/cmsDeliveryApi',
-        identifier: 'getContent',
-    },
-    {
-        module: 'experience/cmsEditorApi',
-        identifier: 'getContent',
-    },
-    {
-        module: 'experience/cmsEditorApi',
-        identifier: 'getContext',
-    },
-    {
-        module: 'experience/navigationMenuApi',
-        identifier: 'getNavigationMenu',
+        module: 'experience/*Api',
+        identifier: '*',
     },
     {
         module: 'lightning/analyticsWaveApi',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "semver": "^7.3.7"
   },
   "devDependencies": {
-    "@lwc/eslint-plugin-lwc": "^1.2.1",
+    "@lwc/eslint-plugin-lwc": "^1.3.0",
     "@salesforce/eslint-plugin-lightning": "^1.0.0",
     "eslint": "^8.14.0",
     "eslint-plugin-import": "^2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,7 +322,7 @@
 
 "@lwc/eslint-plugin-lwc@^1.3.0":
   version "1.3.0"
-  resolved "https://nexus-proxy-prd.soma.salesforce.com/nexus/content/groups/npm-all/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.3.0.tgz#eb47e3bb58228438f5ac869c78923848326d5ef8"
+  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.3.0.tgz#eb47e3bb58228438f5ac869c78923848326d5ef8"
   integrity sha512-WkHhIW+C23QTzuUTs3htjp/klZiKCMS/wUroXs7WqtQdZxhBmDLbdR+1WOp/liL27L80KVjdCq9pvLtS1UQKjg==
   dependencies:
     minimatch "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,10 +320,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@lwc/eslint-plugin-lwc@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.2.1.tgz#4953dff14d2dabad22c967d4fd4b666ef45dbcd9"
-  integrity sha512-13a5XOultegAc4i4SyFk9367KOvvRy40zbRSKkApcNa9uMI6n9/C/yFMvwve6Mp6PaIsGXlKFWNkzwj+nADEzw==
+"@lwc/eslint-plugin-lwc@^1.3.0":
+  version "1.3.0"
+  resolved "https://nexus-proxy-prd.soma.salesforce.com/nexus/content/groups/npm-all/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.3.0.tgz#eb47e3bb58228438f5ac869c78923848326d5ef8"
+  integrity sha512-WkHhIW+C23QTzuUTs3htjp/klZiKCMS/wUroXs7WqtQdZxhBmDLbdR+1WOp/liL27L80KVjdCq9pvLtS1UQKjg==
   dependencies:
     minimatch "^5.0.1"
 


### PR DESCRIPTION
Upgrade to `@lwc/eslint-plugin-lwc` v1.3.0 to benefit from the pattern matching support that got added recently. Adjust the `base.js` configuration to whitelist the `experience` and `commerce` API related wire adapters in the rule `@lwc/lwc/no-unknown-wire-adapters` and respectively blacklist the same adapters in the rule `@lwc/lwc/no-unexpected-wire-adapter-usages`.