### PR TITLE
fix: fix whitelisted commerce and experience wires @W-11390210

### DIFF
--- a/base.js
+++ b/base.js
@@ -19,12 +19,12 @@ const KNOWN_WIRE_ADAPTERS = [
     // All commerce API adapters
     {
         module: 'commerce/*Api',
-        identifier: '*',
+        identifier: '*Adapter',
     },
     // All experience API adapters
     {
         module: 'experience/*Api',
-        identifier: '*',
+        identifier: 'get*',
     },
 ];
 
@@ -32,12 +32,12 @@ const WIRE_ADAPTERS_WITH_RESTRICTED_USE = [
     // All commerce API adapters
     {
         module: 'commerce/*Api',
-        identifier: '*',
+        identifier: '*Adapter',
     },
     // All experience API adapters
     {
         module: 'experience/*Api',
-        identifier: '*',
+        identifier: 'get*',
     },
     {
         module: 'lightning/analyticsWaveApi',


### PR DESCRIPTION
This adds more restrictive whitelisting/blacklisting patterns to prevent falsely blocked `commerce` or `experience` API exports.