### PR TITLE
chore: include ssr.js in package.json's files[]

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "extended.js",
     "i18n.js",
     "index.js",
-    "recommended.js"
+    "recommended.js",
+    "ssr.js"
   ],
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
`ssr.js` is not included in what's shipped to NPM.