### PR TITLE
fix: add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@babel/eslint-parser": "~7.25.9",
         "@eslint/js": "^9.17.0",
         "eslint-restricted-globals": "~0.2.0",
+        "globals": "~15.14.0",
         "semver": "^7.6.2"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,11 @@ globals@^14.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
+globals@~15.14.0:
+  version "15.14.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-15.14.0.tgz#b8fd3a8941ff3b4d38f3319d433b61bbb482e73f"
+  integrity sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==
+
 globalthis@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.4.tgz#7430ed3a975d97bfb59bcce41f5cabbafa651236"


### PR DESCRIPTION
globals was being pulled in as a transitive dependency